### PR TITLE
Respond to feedback

### DIFF
--- a/templates/usgs-location-oriented.j2
+++ b/templates/usgs-location-oriented.j2
@@ -153,8 +153,8 @@
                 "publisher": "U.S. Geological Survey"
               }
             },
-            {% if stream['observedArea'] is defined and stream['observedArea']['phenomenonTime'] %}
-              "temporalCoverage": "{{ stream['observedArea']['phenomenonTime'] }}",
+            {% if stream['phenomenonTime']  %}
+              "temporalCoverage": "{{ stream['phenomenonTime'] }}",
             {% endif %}
 
             {# dc and dcat are not provided in the raw jsonld, must be hardcoded #}

--- a/templates/usgs-location-oriented.j2
+++ b/templates/usgs-location-oriented.j2
@@ -140,8 +140,8 @@
               {#
               "qudt:hasQuantityKind": "qudt-quantkinds:VolumeFlowRate",
               "unitCode": "qudt-units:FT3-PER-SEC",
-              "measurementTechnique": "observation",
               #}
+              "measurementTechnique": "observation",
 
               "measurementMethod": {
                 


### PR DESCRIPTION
Responds to templating feedback. Believe I have the majority of this, so it was a small edit.

> theres two missing concepts:
> 
> `schema:temporalCoverage` under a `schema:Dataset` can be imported from the Datastream `phenomenonTime`

I believe I had this, if I am understanding correctly, but just had the incorrect key so it wasn't showing up. 

> and for USGS STA only,
> 
> `"measurementTechnique": "observation"`, can be at the `schema:Dataset` level as well

Had it commented out; uncommented this. Wasn't sure previously if all USGS outputs were considered observations in this dataset.