### PR TITLE
Add schema:Place to wqp

### DIFF
--- a/templates/jsonld/WQP_Things/collections/items/item.jsonld
+++ b/templates/jsonld/WQP_Things/collections/items/item.jsonld
@@ -22,7 +22,8 @@
     "@id": "{{ data['@id'] }}",
     "@type": [
       "hyf:HY_HydrometricFeature",
-      "hyf:HY_HydroLocation"
+      "hyf:HY_HydroLocation",
+      "Place"
     ],
     
     {%- if data['monitoringLocationType'] %}


### PR DESCRIPTION
Add schema:place to wqp. This keeps everything geospatial as a `schema:Place` in the Graph and makes queries a bit easier. The shacl shape prechecks essentially require use to determine if it is a dataset or a place first before validating